### PR TITLE
Fix /documents test

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,15 +31,13 @@ const client = new MongoClient(url);
 
 let db;
 // Use connect method to connect to the Server
-setTimeout(() => {
-  client.connect(function(err) {
-    if (err) {
-      return console.error(err);
-    }
-    console.log("Connected successfully to database");
-    db = client.db(MONGO_DATABASE_NAME);
-  });
-}, 2000);
+client.connect(function(err) {
+  if (err) {
+    return console.error(err);
+  }
+  console.log("Connected successfully to database");
+  db = client.db(MONGO_DATABASE_NAME);
+});
 
 // Api
 const app = express();

--- a/test/sample.js
+++ b/test/sample.js
@@ -38,7 +38,7 @@ describe('API /documents', () => {
                 res.should.have.status(200);
                 res.should.to.be.json;
                 res.body.should.be.a('array');
-                res.body.length.should.be.eql(0);
+                res.body.length.should.be.eql(3);
                 done();
             });
     });


### PR DESCRIPTION
The /documents test fails for 2 reasons:
1. The database connection happened after 2 seconds. This changes it to happens instantly when running index.js (which the test uses)
2. By default the database is seeded with 3 entries, and the test fails since it looks for 0 entries